### PR TITLE
Add timings to various status events

### DIFF
--- a/test/writer.test.js
+++ b/test/writer.test.js
@@ -116,7 +116,7 @@ describe('Writer', function () {
       });
 
       it('writes an error if statusInfo contains an error with timing information', function (done) {
-        writer.timings.set('forever', performance.now() - 20)
+        writer.timings.set('forever', performance.now() - 20);
         writer.write('forever', {
           error: new Error('Penguins are flying'),
           eventType: 'event',
@@ -146,7 +146,7 @@ describe('Writer', function () {
       });
 
       it('writes the message to the stream with timing information', function (done) {
-        writer.timings.set('forever', performance.now() - 20)
+        writer.timings.set('forever', performance.now() - 20);
         writer.write('forever', { eventType: 'event' }, function () {
           assume(writer.writeStream.write).calledWithMatch({
             ...expectedMessage,
@@ -191,7 +191,7 @@ describe('Writer', function () {
       });
 
       it('ends the stream with timing information', function (done) {
-        writer.timings.set('forever', performance.now() - 20)
+        writer.timings.set('forever', performance.now() - 20);
         writer.end('forever', { eventType: 'complete' }, function () {
           assume(writer.writeStream.end).calledWithMatch({
             ...expectedMessage,

--- a/test/writer.test.js
+++ b/test/writer.test.js
@@ -3,6 +3,7 @@ const Writer = require('../writer');
 const assume = require('assume');
 const sinon = require('sinon');
 const nsqStream = require('nsq-stream');
+const { performance } = require('perf_hooks');
 assume.use(require('assume-sinon'));
 
 describe('Writer', function () {
@@ -82,7 +83,7 @@ describe('Writer', function () {
         writer.writeStream = null;
         sinon.stub(writer, 'buildStatusMessage');
 
-        writer.write({ eventType: 'complete' }, function () {
+        writer.write(null, { eventType: 'complete' }, function () {
           assume(writer.buildStatusMessage).not.called();
           done();
         });
@@ -91,14 +92,14 @@ describe('Writer', function () {
       it('logs an error if the stream is no longer writable', function (done) {
         writer.writeStream._writableState.ended = true;
 
-        writer.write({ eventType: 'complete' }, function () {
+        writer.write(null, { eventType: 'complete' }, function () {
           assume(mockLog.error).calledWith('Unable to write to stream', sinon.match.object);
           done();
         });
       });
 
       it('writes an error if statusInfo contains an error', function (done) {
-        writer.write({
+        writer.write(null, {
           error: new Error('Penguins are flying'),
           eventType: 'event',
           message: 'Penguins grounded'
@@ -114,11 +115,43 @@ describe('Writer', function () {
         });
       });
 
+      it('writes an error if statusInfo contains an error with timing information', function (done) {
+        writer.timings.set('forever', performance.now() - 20)
+        writer.write('forever', {
+          error: new Error('Penguins are flying'),
+          eventType: 'event',
+          message: 'Penguins grounded'
+        },
+        function () {
+          assume(writer.writeStream.write).calledWithMatch({
+            ...expectedMessage,
+            eventType: 'error',
+            message: 'Penguins are flying',
+            timing: sinon.match.number
+          }, sinon.match.func);
+
+          done();
+        });
+      });
+
       it('writes the message to the stream', function (done) {
-        writer.write({ eventType: 'event' }, function () {
+        writer.write(null, { eventType: 'event' }, function () {
           assume(writer.writeStream.write).calledWithMatch({
             ...expectedMessage,
             eventType: 'event'
+          }, sinon.match.func);
+
+          done();
+        });
+      });
+
+      it('writes the message to the stream with timing information', function (done) {
+        writer.timings.set('forever', performance.now() - 20)
+        writer.write('forever', { eventType: 'event' }, function () {
+          assume(writer.writeStream.write).calledWithMatch({
+            ...expectedMessage,
+            eventType: 'event',
+            timing: sinon.match.number
           }, sinon.match.func);
 
           done();
@@ -131,7 +164,7 @@ describe('Writer', function () {
         writer.writeStream = null;
         sinon.stub(writer, 'buildStatusMessage');
 
-        writer.end({ eventType: 'complete' }, function () {
+        writer.end(null, { eventType: 'complete' }, function () {
           assume(writer.buildStatusMessage).not.called();
           done();
         });
@@ -140,17 +173,30 @@ describe('Writer', function () {
       it('logs an error if the stream is no longer writable', function (done) {
         writer.writeStream._writableState.ended = true;
 
-        writer.end({ eventType: 'complete' }, function () {
+        writer.end(null, { eventType: 'complete' }, function () {
           assume(mockLog.error).calledWith('Unable to end stream', sinon.match.object);
           done();
         });
       });
 
       it('ends the stream with the given message', function (done) {
-        writer.end({ eventType: 'complete' }, function () {
+        writer.end(null, { eventType: 'complete' }, function () {
           assume(writer.writeStream.end).calledWithMatch({
             ...expectedMessage,
             eventType: 'complete'
+          }, sinon.match.func);
+
+          done();
+        });
+      });
+
+      it('ends the stream with timing information', function (done) {
+        writer.timings.set('forever', performance.now() - 20)
+        writer.end('forever', { eventType: 'complete' }, function () {
+          assume(writer.writeStream.end).calledWithMatch({
+            ...expectedMessage,
+            eventType: 'complete',
+            timing: sinon.match.number
           }, sinon.match.func);
 
           done();

--- a/writer.js
+++ b/writer.js
@@ -13,6 +13,11 @@ function Writer(opts = {}) {
   this.timings = new Map();
 }
 
+/**
+ * Starts a timer for the given key, if additional arguments are provided, also writes a status message
+ * @param {String} key - Timing key to associate with the timer
+ * @param {...Any} rest - Additional arguments used to call write (not including a timer key)
+ */
 Writer.prototype.timerStart = function timerStart(key, ...rest) {
   this.timings.set(key, performance.now());
   if (rest && rest.length > 0) {
@@ -24,6 +29,8 @@ Writer.prototype.timerStart = function timerStart(key, ...rest) {
  * Combines the spec with status information
  *
  * @function buildStatusMessage
+ * @param {String?} key - Timing key to use, if one exists, timing information will
+ * be added to the status message
  * @param {Object} statusInfo - Status information
  * @returns {Object} - The combined message object
  * @api private
@@ -55,6 +62,8 @@ Writer.prototype.buildStatusMessage = function buildStatusMessage(key, statusInf
  *
  * @function _doStreamAction
  * @param {String} action - Which stream action execute
+ * @param {String?} key - Timing key to use, if one exists, timing information will
+ * be added to the status message
  * @param {Object} statusInfo - Status information
  * @param {Function} done - Callback
  * @returns {undefined}
@@ -77,6 +86,8 @@ Writer.prototype._doStreamAction = function _doStreamAction(action, key, statusI
  * Write to the NSQ stream
  *
  * @function write
+ * @param {String?} key - Timing key to use, if one exists, timing information will
+ * be added to the status message
  * @param {Object} statusInfo - Status information
  * @param {Function} done - Callback
  * @api public
@@ -89,6 +100,8 @@ Writer.prototype.write = function write(key, statusInfo = {}, done = () => {}) {
  * End the stream and write a final message
  *
  * @function end
+ * @param {String?} key - Timing key to use, if one exists, timing information will
+ * be added to the status message
  * @param {Object} statusInfo - Status information
  * @param {Function} done - Callback
  * @api public


### PR DESCRIPTION
Allowing us to more easily track how long various stages are taking.

There is a sister PR for [`carpenterd`](https://github.com/godaddy/carpenterd/pull/37).

I opted for using `performance.now()` over `Date.now()`, for better timing information, but should be easy enough to change if we prefer that.