### PR TITLE
Conditional promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ See the example config `config.example.json` in this repo.
 - `datastar` the configuration for cassandra that gets passed directly to [`datastar`][datastar].
 
 
+## Build Options
+### promote
+When work is queued with `carpenterd-worker` it can optionally be marked to disable build promotion. Normally when a build completes it is marked as the build-head.  Meaning it will be the build that is used for the given environment for that package. If the status message used to queue the build contains
+
+```json
+{
+  ...otherProperties,
+  "promote": false
+}
+```
+
+Then it will be built _only_ and not promoted / served for the given environment.
+
 ## Status-Api
 
 Carpenterd-worker supports posting messages to the [warehouse.ai] status-api via NSQ.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "parallel-transform": "~1.1.0",
     "pkgcloud": "^1.5.0",
     "retryme": "^1.0.0",
+    "rip-out": "^1.0.0",
     "slay-config": "~2.2.0",
     "uuid": "~3.0.1",
     "warehouse-models": "^5.6.0",

--- a/test/builder.test.js
+++ b/test/builder.test.js
@@ -88,7 +88,7 @@ describe('Builder', function () {
   });
 
   describe('builder.build', function () {
-    it('should successfully fetch, build and publish assets', function (done) {
+    it('should successfully fetch, build and publish assets with implicit promotion', function (done) {
       builder.assets.publish.yieldsAsync(null, null);
       sinon.stub(builder.models.Build, 'findOne').yieldsAsync(null, null);
       sinon.stub(builder.models.BuildHead, 'findOne').yieldsAsync(null, null);
@@ -100,7 +100,55 @@ describe('Builder', function () {
       }, (err) => {
         assume(err).is.falsey();
         assume(builder.assets.publish).is.called(1);
-        assume(builder.assets.publish).is.calledWith(sinon.match.object, sinon.match.object, sinon.match.func);
+        assume(builder.assets.publish).is.calledWithMatch({
+          name: 'test',
+          version: '1.0.0',
+          env: 'dev'
+        }, { promote: true }, sinon.match.func);
+        done();
+      });
+    });
+
+    it('should successfully fetch, build and publish assets with explicit promotion', function (done) {
+      builder.assets.publish.yieldsAsync(null, null);
+      sinon.stub(builder.models.Build, 'findOne').yieldsAsync(null, null);
+      sinon.stub(builder.models.BuildHead, 'findOne').yieldsAsync(null, null);
+
+      builder.build({
+        name: 'test',
+        version: '1.0.0',
+        env: 'dev',
+        promote: true
+      }, (err) => {
+        assume(err).is.falsey();
+        assume(builder.assets.publish).is.called(1);
+        assume(builder.assets.publish).is.calledWithMatch({
+          name: 'test',
+          version: '1.0.0',
+          env: 'dev'
+        }, { promote: true }, sinon.match.func);
+        done();
+      });
+    });
+
+    it('should successfully fetch, build and publish assets without promotion', function (done) {
+      builder.assets.publish.yieldsAsync(null, null);
+      sinon.stub(builder.models.Build, 'findOne').yieldsAsync(null, null);
+      sinon.stub(builder.models.BuildHead, 'findOne').yieldsAsync(null, null);
+
+      builder.build({
+        name: 'test',
+        version: '1.0.0',
+        env: 'dev',
+        promote: false
+      }, (err) => {
+        assume(err).is.falsey();
+        assume(builder.assets.publish).is.called(1);
+        assume(builder.assets.publish).is.calledWithMatch({
+          name: 'test',
+          version: '1.0.0',
+          env: 'dev'
+        }, { promote: false }, sinon.match.func);
         done();
       });
     });


### PR DESCRIPTION
This allows a flag to be sent in the NSQ message to disable promotion of the build to be the build-head.  `{ promote: false, ...otherProperties }`

This is a continuation of allowing warehouse.ai to be able to build things (so they can be tested) before promoting them to an environment.  This is useful to test out the minified version of the package before shipping to all customers, or if there are specific things you only enable for a given environment, etc.

The `bffs` work to allow this flag is already complete.  `carpenterd` and `feedsme` work will follow, and then eventually enabling it from an api at the `warehouse.ai` layer and then the `wrhs` cli.